### PR TITLE
Correct some escaping in Tutorial

### DIFF
--- a/src/System/IO/Streams/Tutorial.hs
+++ b/src/System/IO/Streams/Tutorial.hs
@@ -84,8 +84,8 @@ preserve their handle-like API. For example, you can map a function over an
 stream that returns transformed values:
 
 @
-ghci> oldHandle <- S.'System.IO.Streams.fromList' [1, 2, 3]
-ghci> newHandle <- S.'System.IO.Streams.mapM' (\x -> 'return' (x * 10)) oldHandle
+ghci> oldHandle \<- S.'System.IO.Streams.List.fromList' [1, 2, 3]
+ghci> newHandle \<- S.'System.IO.Streams.Combinators.mapM' (\\x -\> 'return' (x * 10)) oldHandle
 ghci> S.'System.IO.Streams.read' newHandle
 10
 ghci> -- We can still view the stream through the old handle


### PR DESCRIPTION
There were a bunch of rendering glitches in the Tutorial's documentation comments. Mostly seemed to be down to insufficient escaping.

AfC
