### PR TITLE
Export profiling annotations for exported symbols

### DIFF
--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -83,7 +83,7 @@ Library
   ghc-options:       -O2 -Wall -fwarn-tabs -funbox-strict-fields -threaded
                      -fno-warn-unused-do-bind
 
-  ghc-prof-options:  -prof -auto-all
+  ghc-prof-options:  -prof -fprof-auto-exported
 
   Exposed-modules:   System.IO.Streams,
                      System.IO.Streams.Attoparsec,


### PR DESCRIPTION
As alluded to by email, GHC has changed the format of the profiling annotation flags. So looking forward, `-auto-all` has become `-fprof-auto`. However, for an external consumer of io-streams, I have found it better to add cost-center annotations only to exported symbols -- ie, the public API of your library; seeing the intricate detail of internal functions within io-streams when profiling _my_ application doesn't really add much; it's enough to know that Streams.gunzip is doing work, for example.

Obviously this setting won't be of much interest to you as one of the library authors, but presumably the entry in the .cabal file should be what is best for people using the library? Not sure how to resolve that tension, but patch attached puts `ghc-prof-options` to `-fprof-auto-exported`.
