### PR TITLE
Fix documentation for withFileAsOutput

### DIFF
--- a/src/System/IO/Streams/File.hs
+++ b/src/System/IO/Streams/File.hs
@@ -70,9 +70,8 @@ unsafeWithFileAsInputStartingAt = withFileAsInputStartingAt
 
 
 ------------------------------------------------------------------------------
--- | Like 'withFileAsInput', but opens the file for writing using the specified
--- IO mode, and attaches the file to an 'OutputStream' instead of an
--- 'InputStream'.
+-- | Open a file for writing and  attaches an 'OutputStream' for you to write
+-- to. The file will be closed on error or completion of your action.
 withFileAsOutput
     :: FilePath                           -- ^ file to open
     -> (OutputStream ByteString -> IO a)  -- ^ function to run


### PR DESCRIPTION
So I see you changed the signature of `withFileAsOutput` again. Documentation was a bit screwy, minor patch attached.

While we're at it, I thought I might mention that the "Ext" suffix seems a bit abrupt. Rather than `withFileAsOutputExt` I might suggest `withFileAsOutputFull`... that is, if you don't want to use a `'` character, as in `withFileAsOutput'`

AfC
