### PR TITLE
Cabal tweaks

### DIFF
--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -9,6 +9,7 @@ Cabal-version:       >= 1.10
 Synopsis:            Simple, composable, and easy-to-use stream I/O
 Tested-With:         GHC==7.6.2, GHC==7.6.1, GHC==7.4.2, GHC==7.4.1,
                      GHC==7.2.2, GHC==7.0.4
+Bug-Reports:         https://github.com/snapframework/io-streams/issues
 Description:
   /Overview/
   .
@@ -273,4 +274,4 @@ Test-suite testsuite
 
 source-repository head
   type:     git
-  location: git://github.com/snapframework/io-streams.git
+  location: https://github.com/snapframework/io-streams.git


### PR DESCRIPTION
after this pull-request, `io-streams` builds out of the box and passes its testsuite with GHC HEAD.
