### PR TITLE
raise bounds on `primitive`

### DIFF
--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -123,7 +123,7 @@ Library
                      bytestring         >= 0.9   && <0.11,
                      bytestring-builder >= 0.10  && <0.11,
                      network            >= 2.3   && <2.7,
-                     primitive          >= 0.2   && <0.6,
+                     primitive          >= 0.2   && <0.7,
                      process            >= 1.1   && <1.3,
                      text               >= 0.10  && <1.3,
                      time               >= 1.2   && <1.6,


### PR DESCRIPTION
The new `primitive` is `0.6`. It seems to work fine. The changelog says:

## Changes in version 0.6

      * Split PrimMonad into two classes to allow automatic lifting of primitive
      operations into monad transformers. The `internal` operation has moved to the
      `PrimBase` class.

which doesn't seem to bear on anything `io-streams` is doing.