### PR TITLE
Bumped attoparsec bound

### DIFF
--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -118,7 +118,7 @@ Library
                      System.IO.Streams.Internal.Search
 
   Build-depends:     base               >= 4     && <5,
-                     attoparsec         >= 0.10  && <0.13,
+                     attoparsec         >= 0.10  && <0.14,
                      bytestring         >= 0.9   && <0.11,
                      bytestring-builder >= 0.10  && <0.11,
                      network            >= 2.3   && <2.7,


### PR DESCRIPTION
to < 0.14, Using io-streams in a project, installed successfully with 'cabal install --allow-newer-', `attoparsec 0.13` installed alongside of latest `io-streams-1.3`