### PR TITLE
io-streams.cabal: allow attoparsec-0.13 in tests as well

### DIFF
--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -199,7 +199,7 @@ Test-suite testsuite
     cpp-options: -DENABLE_PROCESS_TESTS
 
   Build-depends:     base               >= 4     && <5,
-                     attoparsec         >= 0.10  && <0.13,
+                     attoparsec         >= 0.10  && <0.14,
                      bytestring         >= 0.9   && <0.11,
                      bytestring-builder >= 0.10  && <0.11,
                      deepseq            >= 1.2   && <1.5,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <siarheit@google.com>