### PR TITLE
Bump attoparsec, vector bounds (fix issue #44)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# Version 1.3.2.0
+  - Dependency bump for attoparsec 0.13 (another location)
+  - Dependency bump for vector 0.11
+  - Dependency bump for zlib 0.6
+
 # Version 1.3.1.0
   - Dependency bump for attoparsec 0.13.
 

--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -1,5 +1,5 @@
 Name:                io-streams
-Version:             1.3.1.0
+Version:             1.3.2.0
 License:             BSD3
 License-file:        LICENSE
 Category:            Data, Network, IO-Streams
@@ -127,7 +127,7 @@ Library
                      text               >= 0.10  && <1.3,
                      time               >= 1.2   && <1.6,
                      transformers       >= 0.2   && <0.5,
-                     vector             >= 0.7   && <0.11,
+                     vector             >= 0.7   && <0.12,
                      zlib-bindings      >= 0.1   && <0.2
 
   if impl(ghc >= 7.2)
@@ -199,7 +199,7 @@ Test-suite testsuite
     cpp-options: -DENABLE_PROCESS_TESTS
 
   Build-depends:     base               >= 4     && <5,
-                     attoparsec         >= 0.10  && <0.13,
+                     attoparsec         >= 0.10  && <0.14,
                      bytestring         >= 0.9   && <0.11,
                      bytestring-builder >= 0.10  && <0.11,
                      deepseq            >= 1.2   && <1.5,
@@ -212,7 +212,7 @@ Test-suite testsuite
                      text               >= 0.10  && <1.3,
                      time               >= 1.2   && <1.6,
                      transformers       >= 0.2   && <0.5,
-                     vector             >= 0.7   && <0.11,
+                     vector             >= 0.7   && <0.12,
                      zlib-bindings      >= 0.1   && <0.2,
 
                      HUnit                      >= 1.2      && <2,
@@ -220,7 +220,7 @@ Test-suite testsuite
                      test-framework             >= 0.6      && <0.9,
                      test-framework-hunit       >= 0.2.7    && <0.4,
                      test-framework-quickcheck2 >= 0.2.12.1 && <0.4,
-                     zlib                       >= 0.5      && <0.6
+                     zlib                       >= 0.5      && <0.7
 
   if impl(ghc >= 7.2)
     other-extensions: Trustworthy


### PR DESCRIPTION
I ran cabal test, yay:

```
Linking dist/build/testsuite/testsuite ...
Running 1 test suites...
Test suite testsuite: RUNNING...
Test suite testsuite: PASS
Test suite logged to: dist/test/io-streams-1.3.1.0-testsuite.log
1 of 1 test suites (1 of 1 test cases) passed.
```
