### PR TITLE
add a chunkListWith function to .List

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# Version 1.3.3.0
+  - Added a new convenience function, like `chunkList` but with a predicate for
+    when to split, taking current element and current chunk length:
+    ```haskell
+chunkListWith :: (a -> Int -> Bool) -> InputStream a -> IO (InputStream [a])
+    ```
+
 # Version 1.3.2.0
   - Dependency bump for attoparsec 0.13 (another location)
   - Dependency bump for vector 0.11

--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -1,5 +1,5 @@
 Name:                io-streams
-Version:             1.3.2.0
+Version:             1.3.3.0
 License:             BSD3
 License-file:        LICENSE
 Category:            Data, Network, IO-Streams

--- a/src/System/IO/Streams/List.hs
+++ b/src/System/IO/Streams/List.hs
@@ -168,6 +168,8 @@ chunkList n input = if n <= 0
 -- ghci> 'fromList' ['a'..'z'] >>= 'chunkListWith' (\x n -> n>=4 && x `elem` "aeiouy") >>= 'toList'
 -- ["abcde","fghi","jklmno","pqrstu","vwxy","z"]
 -- @
+--
+-- /Since: 1.3.3.0./
 chunkListWith :: (a -> Int -> Bool)    -- ^ break predicate
               -> InputStream a         -- ^ stream to process
               -> IO (InputStream [a])

--- a/test/System/IO/Streams/Tests/List.hs
+++ b/test/System/IO/Streams/Tests/List.hs
@@ -14,7 +14,8 @@ import           System.IO.Streams.List
 import           System.IO.Streams.Tests.Common (expectExceptionH)
 
 tests :: [Test]
-tests = [ testChunkJoin ]
+tests = [ testChunkJoin, testChunkWithJoin ]
+
 
 
 testChunkJoin :: Test
@@ -32,3 +33,26 @@ testChunkJoin = testCase "list/chunkList and join" $ do
                             >>= concatLists
                             >>= toList
                             >>= assertEqual "concatlists" [1..12]
+
+testChunkWithJoin :: Test
+testChunkWithJoin = testCase "list/chunkListWith and join" $ do
+    fromList [1..10 :: Int] >>= chunkListWith (\_ n -> n>=3)
+                            >>= toList
+                            >>= assertEqual "chunkListWith" [ [1,2,3]
+                                                        , [4,5,6]
+                                                        , [7,8,9]
+                                                        , [10]
+                                                        ]
+    fromList [1..12 :: Int] >>= chunkListWith (\_ n -> n>=3)
+                            >>= concatLists
+                            >>= toList
+                            >>= assertEqual "concatlists" [1..12]
+
+    fromList ['a'..'z' :: Char] >>= chunkListWith (\x n -> n>=4 && x `elem` "aeiouy")
+                            >>= toList
+                            >>= assertEqual "chunkListWith" ["abcde"
+                                                            ,"fghi"
+                                                            ,"jklmno"
+                                                            ,"pqrstu"
+                                                            ,"vwxy"
+                                                            ,"z"]


### PR DESCRIPTION
takes a predicate that sees the current element and chunk length

I found this useful anyway, but I don't know if it's generally useful enough to be included?
