### PR TITLE
Relax upper bounds on some core packages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
+# Version 1.3.5.0
+  - Add support for latest `process`, `time`, and `transformers` releases
+    (and thereby indirectly for the upcoming GHC 8.0)
+
 # Version 1.3.4.0
-Added `System.IO.Streams.Handle.handleToStreams`, to conveniently
-create an `InputStream`/`OutputStream` pair.
+  - Added `System.IO.Streams.Handle.handleToStreams`, to conveniently
+    create an `InputStream`/`OutputStream` pair.
 
 # Version 1.3.3.1
   - Fixed a testsuite compile error on GHC >= 7.10.

--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -1,5 +1,5 @@
 Name:                io-streams
-Version:             1.3.4.0
+Version:             1.3.5.0
 License:             BSD3
 License-file:        LICENSE
 Category:            Data, Network, IO-Streams

--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -123,10 +123,10 @@ Library
                      bytestring-builder >= 0.10  && <0.11,
                      network            >= 2.3   && <2.7,
                      primitive          >= 0.2   && <0.7,
-                     process            >= 1.1   && <1.3,
+                     process            >= 1.1   && <1.5,
                      text               >= 0.10  && <1.3,
-                     time               >= 1.2   && <1.6,
-                     transformers       >= 0.2   && <0.5,
+                     time               >= 1.2   && <1.7,
+                     transformers       >= 0.2   && <0.6,
                      vector             >= 0.7   && <0.12,
                      zlib-bindings      >= 0.1   && <0.2
 
@@ -208,10 +208,10 @@ Test-suite testsuite
                      mtl                >= 2     && <3,
                      network            >= 2.3   && <2.7,
                      primitive          >= 0.2   && <0.7,
-                     process            >= 1     && <1.3,
+                     process            >= 1.1   && <1.5,
                      text               >= 0.10  && <1.3,
-                     time               >= 1.2   && <1.6,
-                     transformers       >= 0.2   && <0.5,
+                     time               >= 1.2   && <1.7,
+                     transformers       >= 0.2   && <0.6,
                      vector             >= 0.7   && <0.12,
                      zlib-bindings      >= 0.1   && <0.2,
 


### PR DESCRIPTION
These new major versions (which are all already up on Hackage) come with
GHC 8.0RC. I've managed to build the testsuite and all 111 tests pass
just fine.