### PR TITLE
tests: don't hardcode path to /usr/bin/tr

### DIFF
--- a/test/System/IO/Streams/Tests/Process.hs
+++ b/test/System/IO/Streams/Tests/Process.hs
@@ -40,7 +40,7 @@ testInteractiveCommand = testCase "process/interactiveCommand" $ do
 ------------------------------------------------------------------------------
 testInteractiveProcess :: Test
 testInteractiveProcess = testCase "process/interactiveProcess" $ do
-    (out, err) <- Streams.runInteractiveProcess "/usr/bin/tr" ["a-z", "A-Z"]
+    (out, err) <- Streams.runInteractiveProcess "tr" ["a-z", "A-Z"]
                                                 Nothing Nothing
                       >>= run [inputdata]
     assertEqual "interactiveProcess" expected out


### PR DESCRIPTION
Some systems have tr in a different location (example: NixOS), so it is
best to just rely on $PATH to find tr and not hardcode any location.