### PR TITLE
Add support for network-3.0.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ docs/templates/out
 .cabal-sandbox/
 cabal.sandbox.config
 cabal.project.local
+.stack-work/

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Version 1.5.0.2
+Fix [stackage#4312](https://github.com/commercialhaskell/stackage/issues/4312): Relax `network` upper bound
+
 # Version 1.5.0.1
 Bugfix: `concurrentMerge []` should not block forever, even if this case is
 pathological.

--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -1,5 +1,5 @@
 Name:                io-streams
-Version:             1.5.0.1
+Version:             1.5.0.2
 License:             BSD3
 License-file:        LICENSE
 Category:            Data, Network, IO-Streams

--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -124,7 +124,7 @@ Library
                      attoparsec         >= 0.10  && <0.14,
                      bytestring         >= 0.9   && <0.11,
                      bytestring-builder >= 0.10  && <0.11,
-                     network            >= 2.3   && <2.9,
+                     network            >= 2.3   && <3.1,
                      primitive          >= 0.2   && <0.7,
                      process            >= 1.1   && <1.7,
                      text               >= 0.10  && <1.3,

--- a/test/System/IO/Streams/Tests/Concurrent.hs
+++ b/test/System/IO/Streams/Tests/Concurrent.hs
@@ -47,7 +47,7 @@ testConcurrentMerge = testCase "concurrent/concurrentMerge" $ do
                                  chans
     inputs <- mapM Streams.chanToInput chans
     resultMVar <- newEmptyMVar
-    forkIO (Streams.concurrentMerge inputs >>= Streams.toList
+    _ <- forkIO (Streams.concurrentMerge inputs >>= Streams.toList
                                            >>= putMVar resultMVar)
     putMVar firstMVar 0
     result <- takeMVar resultMVar

--- a/test/System/IO/Streams/Tests/Network.hs
+++ b/test/System/IO/Streams/Tests/Network.hs
@@ -39,7 +39,7 @@ testSocket = testCase "network/socket" $
   where
     -- compats
 #if MIN_VERSION_network(2,7,0)
-    mkAddr = pure . N.tupleToHostAddress
+    mkAddr = return . N.tupleToHostAddress
     defaultPort = N.defaultPort
     close = N.close
     bind = N.bind


### PR DESCRIPTION
### Changes

- Relax `network` upper bound to fix https://github.com/commercialhaskell/stackage/issues/4312
- Address test failures in a backward compatible manner by conditionally switching to newer APIs suggested by `network-2.7.0` [docs for Network.Socket](https://hackage.haskell.org/package/network-2.7.0.0/docs/Network-Socket.html).
- Bumped changelog and cabal

### CI

- Looks like Travis isn't enabled here yet; however the following shows Travis run results on the fork: https://travis-ci.com/naushadh/io-streams/builds/97970263
- Failures appear to be unrelated to the incoming change, caused by an existing cabal flag:
```bash
$ (cd io-streams-* && cabal check)
Warning: These warnings may cause trouble when distributing the package:
Warning: 'ghc-options/ghc-prof-options: -fprof*' profiling flags are typically
not appropriate for a distributed library package. These flags are useful to
profile this package, but when profiling other packages that use this one
these flags clutter the profile output with excessive detail. If you think
other packages really want to see cost centres from this package then use
'-fprof-auto-exported' which puts cost centres only on exported functions.
Alternatively, if you want to use this, make it conditional based on a Cabal
configuration flag (with 'manual: True' and 'default: False') and enable that
flag during development.
Warning: 'ghc-options/ghc-prof-options: -fprof*' profiling flags are typically
not appropriate for a distributed library package. These flags are useful to
profile this package, but when profiling other packages that use this one
these flags clutter the profile output with excessive detail. If you think
other packages really want to see cost centres from this package then use
'-fprof-auto-exported' which puts cost centres only on exported functions.
Alternatively, if you want to use this, make it conditional based on a Cabal
configuration flag (with 'manual: True' and 'default: False') and enable that
flag during development.
The command "(cd io-streams-* && cabal check)" exited with 1.
```