### PR TITLE
Add `contraunzip`.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,6 +3,7 @@ IOStreams Contributors:
 
   - Gregory Collins <greg@gregorycollins.net>
   - Gabriel Gonzalez <gabriel439@gmail.com>
+  - Ignat Insarov <kindaro@gmail.com>
 
 ------------------------------------------------------------------------------
 Contains some code ported from the "blaze-builder-enumerator" package by Simon

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Version 1.5.2.0
+- Add `contraunzip`.
+
 # Version 1.5.1.0
 Fix [stackage#4312](https://github.com/commercialhaskell/stackage/issues/4312): Relax `network` upper bound
 

--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -1,5 +1,5 @@
 Name:                io-streams
-Version:             1.5.1.0
+Version:             1.5.2.0
 License:             BSD3
 License-file:        LICENSE
 Category:            Data, Network, IO-Streams

--- a/src/System/IO/Streams/Combinators.hs
+++ b/src/System/IO/Streams/Combinators.hs
@@ -47,6 +47,7 @@ module System.IO.Streams.Combinators
  , zipWith
  , zipWithM
  , unzip
+ , contraunzip
 
    -- * Utility
  , intersperse
@@ -748,6 +749,20 @@ unzip os = do
                                     let (a, b) = proj x
                                     modifyIORef buf (. (b:))
                                     return $! Just a)
+
+
+------------------------------------------------------------------------------
+-- | Given two 'OutputStream's, returns a new stream that "unzips" the tuples
+-- being written, writing the two elements to the corresponding given streams.
+--
+-- You can use this together with @'contramap' (\\ x -> (x, x))@ to "fork" a
+-- stream into two.
+--
+-- /Since: 1.5.2.0/
+contraunzip :: OutputStream a -> OutputStream b -> IO (OutputStream (a, b))
+contraunzip sink1 sink2 = makeOutputStream $ \ tuple -> do
+    write (fmap fst tuple) sink1
+    write (fmap snd tuple) sink2
 
 
 ------------------------------------------------------------------------------

--- a/test/System/IO/Streams/Tests/Combinators.hs
+++ b/test/System/IO/Streams/Tests/Combinators.hs
@@ -56,6 +56,7 @@ tests = [ testFilter
         , testZipWith
         , testZipWithM
         , testUnzip
+        , testContraunzip
         , testTake
         , testDrop
         , testGive
@@ -358,6 +359,26 @@ testUnzip = testCase "combinators/unzip" $ do
     toList is3 >>= assertEqual "unzip2-a" (fst $ Prelude.unzip l)
     read is4 >>= assertEqual "unzip2-read-b" Nothing
     read is3 >>= assertEqual "unzip2-read" Nothing
+
+
+------------------------------------------------------------------------------
+testContraunzip :: Test
+testContraunzip = testProperty "combinators/contrazip" $ monadicIO $ forAllM arbitrary prop
+  where
+    prop :: [Int] -> PropertyM IO ( )
+    prop xs = liftQ $ do
+      let ys = fmap show xs
+      xsStream <- fromList xs
+      ysStream <- fromList ys
+      (xsSink, getXs') <- listOutputStream
+      (ysSink, getYs') <- listOutputStream
+      xysStream <- zip xsStream ysStream
+      xysSink <- contraunzip xsSink ysSink
+      connect xysStream xysSink
+      xs' <- getXs'
+      ys' <- getYs'
+      assertEqual "numbers" xs xs'
+      assertEqual "strings" ys ys'
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
I propose adding the function `contraunzip` that splits an output stream in two. It seems to me a reasonable thing to have. The use case I have is a situation where I want to add logging to the input of a black box process — none of the existing functions seem to cover that case.

This function has a nice property of inverting `zip` of two input streams. I used that to quick check it, as you may see.