### PR TITLE
Depends on bytestring-builder on GHC < 7.8 only

### DIFF
--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -130,13 +130,15 @@ Library
   Build-depends:     base               >= 4     && <5,
                      attoparsec         >= 0.10  && <0.14,
                      bytestring         >= 0.9   && <0.11,
-                     bytestring-builder >= 0.10  && <0.11,
                      primitive          >= 0.2   && <0.8,
                      process            >= 1.1   && <1.7,
                      text               >= 0.10  && <1.3,
                      time               >= 1.2   && <1.10,
                      transformers       >= 0.2   && <0.6,
                      vector             >= 0.7   && <0.13
+
+  if !impl(ghc >= 7.8)
+    Build-depends:   bytestring-builder >= 0.10  && <0.11
 
   if impl(ghc >= 7.2)
     other-extensions: Trustworthy
@@ -230,7 +232,6 @@ Test-suite testsuite
   Build-depends:     base,
                      attoparsec,
                      bytestring,
-                     bytestring-builder,
                      deepseq            >= 1.2   && <1.5,
                      directory          >= 1.1   && <2,
                      filepath           >= 1.2   && <2,
@@ -247,6 +248,9 @@ Test-suite testsuite
                      test-framework             >= 0.6      && <0.9,
                      test-framework-hunit       >= 0.2.7    && <0.4,
                      test-framework-quickcheck2 >= 0.2.12.1 && <0.4
+
+  if !impl(ghc >= 7.8)
+    Build-depends:   bytestring-builder
 
   if impl(ghc >= 7.2)
     other-extensions: Trustworthy


### PR DESCRIPTION
It's not needed on newer GHC.