### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -129,7 +129,7 @@ Library
 
   Build-depends:     base               >= 4     && <5,
                      attoparsec         >= 0.10  && <0.14,
-                     bytestring         >= 0.9   && <0.11,
+                     bytestring         >= 0.9   && <0.12,
                      primitive          >= 0.2   && <0.8,
                      process            >= 1.1   && <1.7,
                      text               >= 0.10  && <1.3,


### PR DESCRIPTION
Tested using 
```cabal
packages: .
tests: True

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/attoparsec

source-repository-package
  type: git
  location: https://github.com/Minoru/zlib
  tag: a1b6bcef25774e93be6c3caaf8d99d805242110c

allow-newer:
  regex-base:bytestring,
  regex-posix:bytestring
```