### PR TITLE
Allow text-2.0

### DIFF
--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -132,7 +132,7 @@ Library
                      bytestring         >= 0.9   && <0.12,
                      primitive          >= 0.2   && <0.8,
                      process            >= 1.1   && <1.7,
-                     text               >= 0.10  && <1.3,
+                     text               >= 0.10  && <2.1,
                      time               >= 1.2   && <1.12,
                      transformers       >= 0.2   && <0.6,
                      vector             >= 0.7   && <0.13


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2' -w ghc-9.0.2
