### PR TITLE
Bump deepseq, primitive, text, and CI for GHC 9.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,22 +6,20 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/haskell-CI/haskell-ci
+# For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.16.4
+# version: 0.17.20231010
 #
-# REGENDATA ("0.16.4",["github","io-streams.cabal"])
+# REGENDATA ("0.17.20231010",["github","io-streams.cabal"])
 #
 name: Haskell-CI
 on:
   push:
     branches:
       - master
-      - ci*
   pull_request:
     branches:
       - master
-      - ci*
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -29,19 +27,24 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:focal
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.2
+          - compiler: ghc-9.8.1
             compilerKind: ghc
-            compilerVersion: 9.6.2
+            compilerVersion: 9.8.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.5
+          - compiler: ghc-9.6.3
             compilerKind: ghc
-            compilerVersion: 9.4.5
+            compilerVersion: 9.6.3
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.4.7
+            compilerKind: ghc
+            compilerVersion: 9.4.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -89,21 +92,6 @@ jobs:
             compilerVersion: 7.10.3
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.6.3
-            compilerKind: ghc
-            compilerVersion: 7.6.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.4.2
-            compilerKind: ghc
-            compilerVersion: 7.4.2
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -112,8 +100,9 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -121,8 +110,9 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
@@ -137,10 +127,12 @@ jobs:
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
             echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
             echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
@@ -206,7 +198,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -233,7 +225,6 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package io-streams" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
-          allow-newer: bytestring
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(io-streams)$/; }' >> cabal.project.local
           cat cabal.project
@@ -272,14 +263,6 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
-      - name: prepare for constraint sets
-        run: |
-          rm -f cabal.project.local
-      - name: constraint set bytestring-0.12
-        run: |
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
-          if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
       - name: save cache
         uses: actions/cache/save@v3
         if: always()

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,25 +1,25 @@
-branches: master ci*
+branches: master
 
-constraint-set bytestring-0.12
-  -- bytestring-0.12 requires base >=4.9 (GHC 8.0)
-  ghc: >= 8.0
-  constraints: bytestring >= 0.12
-  --
-  -- The following is silently ignored here:
-  --
-  -- raw-project
-  --   allow-newer: bytestring
-  --
-  tests: True
-  run-tests: True
-
--- The following is meant to be for constraint-set bytestring-0.12 only,
--- but there is currently no way to enable `allow-newer: bytestring`
--- just for the constraint set.
+-- constraint-set bytestring-0.12
+--   -- bytestring-0.12 requires base >=4.9 (GHC 8.0)
+--   ghc: >= 8.0
+--   constraints: bytestring >= 0.12
+--   --
+--   -- The following is silently ignored here:
+--   --
+--   -- raw-project
+--   --   allow-newer: bytestring
+--   --
+--   tests: True
+--   run-tests: True
 --
--- Since core library `bytestring` is constrained to `installed`,
--- it is not harmful to allow newer `bytestring` in the default runs
--- as well---it will have no effect there.
---
-raw-project
-  allow-newer: bytestring
+-- -- The following is meant to be for constraint-set bytestring-0.12 only,
+-- -- but there is currently no way to enable `allow-newer: bytestring`
+-- -- just for the constraint set.
+-- --
+-- -- Since core library `bytestring` is constrained to `installed`,
+-- -- it is not harmful to allow newer `bytestring` in the default runs
+-- -- as well---it will have no effect there.
+-- --
+-- raw-project
+--   allow-newer: bytestring

--- a/io-streams.cabal
+++ b/io-streams.cabal
@@ -8,8 +8,9 @@ Maintainer:          Gregory Collins <greg@gregorycollins.net>
 Cabal-version:       >= 1.10
 Synopsis:            Simple, composable, and easy-to-use stream I/O
 Tested-With:
-  GHc == 9.6.2
-  GHC == 9.4.5
+  GHc == 9.8.1
+  GHc == 9.6.3
+  GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
@@ -19,9 +20,9 @@ Tested-With:
   GHC == 8.2.2
   GHC == 8.0.2
   GHC == 7.10.3
-  GHC == 7.8.4
-  GHC == 7.6.3
-  GHC == 7.4.2
+  -- GHC == 7.8.4
+  -- GHC == 7.6.3
+  -- GHC == 7.4.2
 
 Bug-Reports:         https://github.com/snapframework/io-streams/issues
 Description:
@@ -142,9 +143,9 @@ Library
   Build-depends:     base               >= 4     && <5,
                      attoparsec         >= 0.10  && <0.15,
                      bytestring         >= 0.9   && <0.13,
-                     primitive          >= 0.2   && <0.9,
+                     primitive          >= 0.2   && <0.10,
                      process            >= 1.1   && <1.7,
-                     text               >=0.10   && <1.3  || >= 2.0 && <2.1,
+                     text               >=0.10   && <1.3  || >= 2.0 && <2.2,
                      time               >= 1.2   && <1.13,
                      transformers       >= 0.2   && <0.7,
                      vector             >= 0.7   && <0.14
@@ -244,7 +245,7 @@ Test-suite testsuite
   Build-depends:     base,
                      attoparsec,
                      bytestring,
-                     deepseq            >= 1.2   && <1.5,
+                     deepseq            >= 1.2   && <1.6,
                      directory          >= 1.1   && <2,
                      filepath           >= 1.2   && <2,
                      mtl                >= 2     && <3,


### PR DESCRIPTION
CI morally succeeded here (upstream failures when installing GHC 8.0/8.2).  Please rerun failed workflows (cannot do this myself).

Published this as revision 3: https://hackage.haskell.org/package/io-streams-1.5.2.2/revisions/